### PR TITLE
adding version support - also failing/exiting on retrieval failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ Replace `${release_tag}`, `${GOOS}` and `${GOARCH}` with values for your docker 
 ## ENV VARS
 The following ENV Vars can be set to control sm_entrypoint behavior.
 
-- __SM_VARS__ - Comma separated list of Secrets Manager secret names.
+- __SM_VARS__ - Comma separated list of Secrets Manager secret names, and optionally secret versions separated by a ":".
 
   ```
-  SM_VARS=secret-name-1,[secret-name-2,....]
+  SM_VARS=secret-name-1[:version1],[secret-name-2[:AWSCURRENT],....]
   ```
 
 The __SM_VARS__ ENV var must be set for sm_entrypoint to know what secrets to load into the environment. If it is missing, the

--- a/README.md
+++ b/README.md
@@ -39,7 +39,15 @@ Replace `${release_tag}`, `${GOOS}` and `${GOARCH}` with values for your docker 
 ## ENV VARS
 The following ENV Vars can be set to control sm_entrypoint behavior.
 
-- __SM_VARS__ - Comma separated list of Secrets Manager secret names, and optionally secret versions separated by a ":".
+- __SM_VARS__ - Comma separated list of Secrets Manager secret names, and optionally secret versions separated by a ":". There are two special "version labels", AWSCURRENT and AWSPREVIOUS,
+that describe the stage of a secret.  The secret can only have 1 AWSCURRENT and AWSPREVIOUS label, which automatically gets set if a version label is not applied at update.  AWSCURRENT represents
+the secret that AWS SecretsManager considers the "active" secret and will be the secret the console displays.  The AWSPREVIOUS secret label is applied to the secret that last had the AWSCURRENT
+label.  Neither of these labels is required on a secret.  If you manually create a version label and do not also include AWSCURRENT, neither AWSCURRENT or AWSPREVIOUS labels will be moved.
+
+The version label must be unique on a secret version.  If the same version label is applied to a different secret, then the version label is moved to that different secret.  The PutSecretValue 
+documentation, <https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_PutSecretValue.html>, best describes this functionality.  With care, version labels can be used to store 
+up to 18 different versions of a secrets:
+<https://docs.aws.amazon.com/secretsmanager/latest/userguide/reference_limits.html>
 
   ```
   SM_VARS=secret-name-1[:version1],[secret-name-2[:AWSCURRENT],....]

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ up to 18 different versions of a secrets:
 <https://docs.aws.amazon.com/secretsmanager/latest/userguide/reference_limits.html>
 
   ```
-  SM_VARS=secret-name-1[:version1],[secret-name-2[:AWSCURRENT],....]
+  SM_VARS=secret-name-1[:version1],[secret-name-2[:version2],....]
   ```
 
 The __SM_VARS__ ENV var must be set for sm_entrypoint to know what secrets to load into the environment. If it is missing, the

--- a/loadSecrets.go
+++ b/loadSecrets.go
@@ -22,7 +22,7 @@ func loadSecrets(svc *secretsmanager.SecretsManager, names string) {
       version = s_data[1]
     }
 
-    log.Printf("This SM_VAR is %s\nGetting Variable (name: %s) version %s", temp, name, version)
+    log.Printf("This SM_VAR is %s\nGetting Variable (name: %s, version %s)", temp, name, version)
 
     ret, err := svc.GetSecretValue(&secretsmanager.GetSecretValueInput{
       SecretId: aws.String(name),
@@ -30,13 +30,13 @@ func loadSecrets(svc *secretsmanager.SecretsManager, names string) {
     })
 
     if err != nil {
-      log.Fatalf("secretsmanager:GetSecretValue failed. (name: %s)\n %v", name, err)
+      log.Fatalf("secretsmanager:GetSecretValue failed. (name: %s, version: %s)\n %v", name, version, err)
     }
 
     secrets := make(map[string]string)
     err = json.Unmarshal([]byte(aws.StringValue(ret.SecretString)), &secrets)
     if err != nil {
-      log.Fatalf("secretsmanager:GetSecretValue returns invalid json. (name: %s)\n %v", name, err)
+      log.Fatalf("secretsmanager:GetSecretValue returns invalid json. (name: %s, version: %s)\n %v", name, version, err)
     }
 
     for key, val := range secrets {

--- a/loadSecrets.go
+++ b/loadSecrets.go
@@ -13,20 +13,30 @@ func loadSecrets(svc *secretsmanager.SecretsManager, names string) {
 
   s := strings.Split(names, ",")
 
-  for _, name := range s {
+  for _, temp := range s {
+
+    s_data := strings.Split(temp, ":")
+    name := s_data[0]
+    version := "AWSCURRENT"
+    if len(s_data) > 1 {
+      version = s_data[1]
+    }
+
+    log.Printf("This SM_VAR is %s\nGetting Variable (name: %s) version %s", temp, name, version)
+
     ret, err := svc.GetSecretValue(&secretsmanager.GetSecretValueInput{
       SecretId: aws.String(name),
+      VersionStage: aws.String(version),
     })
 
     if err != nil {
-      log.Printf("secretsmanager:GetSecretValue failed. (name: %s)\n %v", name, err)
-      return
+      log.Fatalf("secretsmanager:GetSecretValue failed. (name: %s)\n %v", name, err)
     }
 
     secrets := make(map[string]string)
     err = json.Unmarshal([]byte(aws.StringValue(ret.SecretString)), &secrets)
     if err != nil {
-      log.Printf("secretsmanager:GetSecretValue returns invalid json. (name: %s)\n %v", name, err)
+      log.Fatalf("secretsmanager:GetSecretValue returns invalid json. (name: %s)\n %v", name, err)
     }
 
     for key, val := range secrets {


### PR DESCRIPTION
This adds the ability to get secretmanager versions... 
This is how to add a secret with a version:`aws secretsmanager put-secret-value --secret-id test-env-poc-secrets --secret-string file://test.json --version-stages mytestversion.1`

Interesting gotcha with secerts versions: If you try to add a version label that already exists, it will move the version label to the new version....